### PR TITLE
Use Bing UHD wallpaper

### DIFF
--- a/lib/providers/provider_bing.dart
+++ b/lib/providers/provider_bing.dart
@@ -57,7 +57,7 @@ final ProviderModel bingProvider = ProviderModel(
           "https://www.bing.com/HPImageArchive.aspx?format=js&idx=0&n=1&mkt=$series";
       JsonMap d = json.decode(await fetch(url))["images"][0];
 
-      final iurl = "https://www.bing.com${d.asCast("url")}";
+      final iurl = "https://www.bing.com${d.asCast("urlbase")}_UHD.jpg";
       final type =
           Uri.parse(iurl).queryParameters["id"]?.split(".").lastOrNull ?? "jpg";
       return ImageModel(


### PR DESCRIPTION
The standard wallpaper that the Bing API returns is `1920x1080`, which looks blurry on retina/4K displays.

Bing wallpapers also offers a UHD wallpaper which can be found by adding `_UHD.jpg` to the `urlbase` of each of the wallpapers returned, which makes things look much sharper.

Thanks for the app BTW 🎉